### PR TITLE
Task 58 add integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [ main, master, feat/* ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create .env file
+        run: |
+          echo "POSTGRES_USER=${{ secrets.POSTGRES_USER || 'user' }}" >> .env
+          echo "POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD || 'password' }}" >> .env
+          echo "POSTGRES_DB=${{ secrets.POSTGRES_DB || 'app_db' }}" >> .env
+          echo "RABBIT_USER=${{ secrets.RABBIT_USER || 'rabbit_user' }}" >> .env
+          echo "RABBIT_PASS=${{ secrets.RABBIT_PASS || 'secure_password_mq' }}" >> .env
+
+      - name: Run Integration Tests
+        run: |
+          docker compose --profile tests up --build --exit-code-from backend-tests backend-tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,6 +127,27 @@ services:
       - backend_net
     restart: unless-stopped
 
+  backend-tests:
+    build:
+      context: .
+      dockerfile: ./tests/Dockerfile
+    profiles: ["tests"]
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+      - RABBITMQ_DEFAULT_USER=${RABBIT_USER}
+      - RABBITMQ_DEFAULT_PASS=${RABBIT_PASS}
+    depends_on:
+      db:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    networks:
+      - backend_net
+      - mq_net
+    command: python3 -m pytest
+
 networks:
   frontend_net:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,8 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
+      backend:
+        condition: service_healthy
     networks:
       - backend_net
       - mq_net

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-alpine
+
+WORKDIR /app
+
+COPY backend/requirements.txt /app/requirements.txt
+
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir \
+        pytest \
+        pytest-asyncio \
+        httpx \
+        pika \
+        psycopg2-binary
+
+COPY . /app

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,49 @@
+import os
+import pytest
+import httpx
+import psycopg2
+import pika
+
+DB_URL = os.getenv("DATABASE_URL", "postgresql://user:password@db:5432/app_db")
+
+RABBIT_USER = os.getenv("RABBIT_USER", "rabbit_user")
+RABBIT_PASS = os.getenv("RABBIT_PASS", "secure_password_mq")
+RABBIT_HOST = os.getenv("RABBIT_HOST", "rabbitmq")
+
+API_URL = os.getenv("API_URL", "http://backend:8000")
+
+@pytest.mark.asyncio
+async def test_api_health():
+    try:
+        async with httpx.AsyncClient(base_url=API_URL, timeout=10.0) as ac:
+            response = await ac.get("/")
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+    except Exception as e:
+        pytest.fail(f"Бэкенд недоступен по адресу {API_URL}: {e}")
+
+def test_db_connection():
+    try:
+        conn = psycopg2.connect(DB_URL)
+        cur = conn.cursor()
+        cur.execute('SELECT 1')
+        assert cur.fetchone()[0] == 1
+        cur.close()
+        conn.close()
+    except Exception as e:
+        pytest.fail(f"Ошибка подключения к базе: {e}")
+
+def test_rabbit_connection():
+    try:
+        credentials = pika.PlainCredentials(RABBIT_USER, RABBIT_PASS)
+        parameters = pika.ConnectionParameters(
+            host=RABBIT_HOST, 
+            credentials=credentials,
+            connection_attempts=3,
+            retry_delay=5
+        )
+        connection = pika.BlockingConnection(parameters)
+        assert connection.is_open
+        connection.close()
+    except Exception as e:
+        pytest.fail(f"RabbitMQ недоступен по адресу {RABBIT_HOST}: {e}")


### PR DESCRIPTION
Запуск через Docker Profiles. Тесты лежат в корне, запускаются изолированным контейнером backend-tests только по профилю. Проверяется одной командой