### PR TITLE
Добавил получение конфига для репозитория по api

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -91,7 +91,6 @@ def update_feedback(owner: str, repo: str, pr_num: int, liked: bool, s: ReviewSe
         raise HTTPException(status_code=404, detail="Ревью для обновления не найдено")
     return {"status": "updated"}
 
-<<<<<<< HEAD
 @worker_router.get("/repo/id")
 def get_repo_id(
     owner: str,
@@ -135,8 +134,6 @@ def get_prompt_config_for_worker(
             detail="Конфигурация промта не найдена"
         )
     return config
-=======
->>>>>>> origin
 
 @admin_router.get("/repos/{owner}/{repo}/pulls/{pr_num}", response_model=PRDetailsResponse)
 def get_pr_analytics(owner: str, repo: str, pr_num: int, s: ReviewService = Depends(get_service)):

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -108,33 +108,6 @@ def get_repo_id(
 
     return {"id": repo_id}
 
-@worker_router.get("/config/model", response_model=ModelConfigResponse)
-def get_model_config_for_worker(
-    repo_id: Optional[int] = None, 
-    s: ConfigService = Depends(get_config_service)
-):
-    config = s.get_model_config(repo_id)
-    if not config:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, 
-            detail="Конфигурация модели не найдена (база не инициализирована дефолтными значениями)"
-        )
-    return config
-
-
-@worker_router.get("/config/prompt", response_model=PromptConfigResponse)
-def get_prompt_config_for_worker(
-    repo_id: Optional[int] = None, 
-    s: ConfigService = Depends(get_config_service)
-):
-    config = s.get_prompt_config(repo_id)
-    if not config:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, 
-            detail="Конфигурация промта не найдена"
-        )
-    return config
-
 @admin_router.get("/repos/{owner}/{repo}/pulls/{pr_num}", response_model=PRDetailsResponse)
 def get_pr_analytics(owner: str, repo: str, pr_num: int, s: ReviewService = Depends(get_service)):
     res = s.get_pr_details(owner, repo, pr_num)

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -91,6 +91,23 @@ def update_feedback(owner: str, repo: str, pr_num: int, liked: bool, s: ReviewSe
         raise HTTPException(status_code=404, detail="Ревью для обновления не найдено")
     return {"status": "updated"}
 
+@worker_router.get("/repo/id")
+def get_repo_id(
+    owner: str,
+    repo: str,
+    s: ReviewService = Depends(get_service)
+):
+    """Получить ID репозитория по owner и repo"""
+    repo_id = s.get_repository_id(owner, repo)
+
+    if not repo_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Репозиторий {owner}/{repo} не найден"
+        )
+
+    return {"id": repo_id}
+
 @worker_router.get("/config/model", response_model=ModelConfigResponse)
 def get_model_config_for_worker(
     repo_id: Optional[int] = None, 

--- a/backend/app/services/review_service.py
+++ b/backend/app/services/review_service.py
@@ -192,8 +192,14 @@ class ReviewService:
         review.is_liked = liked
         self.db.commit()
         return review
-    
 
     def get_all_repositories(self):
         return self.db.query(Repository).order_by(Repository.id.asc()).all()
-    
+
+    def get_repository_id(self, owner: str, repo_name: str) -> Optional[int]:
+        """
+        Получить ID репозитория по owner и name
+        """
+        repo = self.db.query(Repository).filter_by(owner=owner, name=repo_name).first()
+        return repo.id if repo else None
+

--- a/consumer/Dockerfile
+++ b/consumer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim-bookworm
 
 WORKDIR /app
 
@@ -6,10 +6,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends git && \
     rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt .
+COPY consumer/requirements.txt .
+COPY config /app/config
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app/ .
+COPY consumer/app/ .
 
 CMD ["python3", "worker.py"]

--- a/consumer/app/ai_review_runner.py
+++ b/consumer/app/ai_review_runner.py
@@ -8,10 +8,17 @@ import time
 
 import requests
 import structlog
+
 from process_artifacts import process_folder
+from get_settings import (
+    fetch_repo_config,
+    fetch_repo_prompt,
+    apply_config_update,
+    write_prompt_md,
+)
 
 BACKEND_URL = "http://backend:8000"
-config_src_path = "/app/config/.ai-review.yaml"
+BASE_CONFIG_PATH = "/app/config/.ai-review.yaml"
 
 logger = structlog.get_logger()
 
@@ -79,7 +86,7 @@ def run_ai_review_for_pr(
     repo_name: str,
     repo_owner: str,
     pr_number: str,
-    branch: str
+    branch: str,
 ):
     log = logger.bind(repo=f"{repo_owner}/{repo_name}", pr=pr_number, branch=branch)
     temp_dir = tempfile.mkdtemp(prefix=f"ai-review-{repo_name}")
@@ -100,35 +107,38 @@ def run_ai_review_for_pr(
             ["git", "clone", "--branch", branch, auth_repo_url, temp_dir], check=True, capture_output=True, text=True
         )
 
-        config_dst_path = os.path.join(temp_dir, ".ai-review.yaml")
+        config_path = os.path.join(temp_dir, ".ai-review.yaml")
+        shutil.copy(BASE_CONFIG_PATH, config_path)
 
-        if not os.path.exists(config_src_path):
-            raise FileNotFoundError(f"Config not found at {config_src_path}")
-        shutil.copy(config_src_path, config_dst_path)
+        log.info("fetching_repo_settings")
 
-        with open(config_dst_path, "r", encoding="utf-8") as f:
-            config = yaml.safe_load(f)
-        model_name = config["llm"]["meta"]["model"]
+        config_data = fetch_repo_config(repo_owner, repo_name)
+        prompt_data = fetch_repo_prompt(repo_owner, repo_name)
+
+        apply_config_update(
+            yaml_path=config_path,
+            model_config=config_data,
+            prompt_config=prompt_data,
+            repo_owner=repo_owner,
+            repo_name=repo_name,
+            pr_number=pr_number,
+            api_token=github_token
+        )
+
+        prompt_path = os.path.join(temp_dir, "prompt.md")
+        write_prompt_md(prompt_data, prompt_path)
+
+        model_name = config_data["model"]
         ensure_ollama_model(model_name)
 
-        config["vcs"]["pipeline"]["owner"] = repo_owner
-        config["vcs"]["pipeline"]["repo"] = repo_name
-        config["vcs"]["pipeline"]["pull_number"] = str(pr_number)
-        config["vcs"]["http_client"]["api_token"] = github_token
-
-        with open(config_dst_path, "w", encoding="utf-8") as f:
-            yaml.safe_dump(config, f, sort_keys=False, allow_unicode=True)
-
-        log.info("running_ai_review_tool")
+        log.info("running_ai_review")
 
         start_time = time.time()
         subprocess.run(["ai-review", "clear-inline"], cwd=temp_dir, check=True)
         subprocess.run(["ai-review", "show-config"], cwd=temp_dir, check=True)
         subprocess.run(["ai-review", "run-inline"], cwd=temp_dir, check=True)
 
-        end_time = time.time()
-        duration_ms = int((end_time - start_time) * 1000)
-
+        duration_ms = int((time.time() - start_time) * 1000)
         log.info("ai_review_finished")
         log.info("ai_review_duration_ms", duration_ms=duration_ms)
 

--- a/consumer/app/get_settings.py
+++ b/consumer/app/get_settings.py
@@ -1,0 +1,90 @@
+import requests
+import yaml
+import os
+
+BACKEND_URL = os.getenv("BACKEND_URL", "http://backend:8000")
+
+def get_repo_id(owner: str, repo: str) -> int:
+    """Получает ID репозитория от бекенда"""
+    url = f"{BACKEND_URL}/worker/repo/id"
+    resp = requests.get(url, params={"owner": owner, "repo": repo}, timeout=30)
+    resp.raise_for_status()
+    return resp.json()["id"]
+
+def fetch_repo_config(owner: str, repo: str) -> dict:
+    """Получает json от бекенда с конфигом для данного репозитория"""
+    repo_id = get_repo_id(owner, repo)
+    url = f"{BACKEND_URL}/worker/config/model"
+    resp = requests.get(url, params={"repo_id": repo_id}, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+def fetch_repo_prompt(owner: str, repo: str) -> dict:
+    """Получает json от бекенда с промптом для данного репозитория"""
+    repo_id = get_repo_id(owner, repo)
+    url = f"{BACKEND_URL}/worker/config/prompt"
+    resp = requests.get(url, params={"repo_id": repo_id}, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+def apply_config_update(
+    yaml_path: str,
+    model_config: dict | None = None,
+    prompt_config: dict | None = None,
+    repo_owner: str | None = None,
+    repo_name: str | None = None,
+    pr_number: str | None = None,
+    api_token: str | None = None,
+):
+    with open(yaml_path, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f) or {}
+
+    if model_config:
+        llm = config.setdefault("llm", {}).setdefault("meta", {})
+
+        llm["model"] = model_config.get("model", llm.get("model"))
+        llm["max_tokens"] = model_config.get("max_tokens", llm.get("max_tokens"))
+        llm["temperature"] = model_config.get("temperature", llm.get("temperature"))
+        llm["num_ctx"] = model_config.get("num_ctx", llm.get("num_ctx"))
+        llm["top_p"] = model_config.get("top_p", llm.get("top_p"))
+        llm["repeat_penalty"] = model_config.get("repeat_penalty", llm.get("repeat_penalty"))
+        llm["seed"] = model_config.get("seed", llm.get("seed"))
+
+        config.setdefault("llm", {}).setdefault("http_client", {})[
+            "timeout"
+        ] = model_config.get(
+            "llm_http_client_timeout",
+            config.get("llm", {}).get("http_client", {}).get("timeout"),
+        )
+
+        config.setdefault("core", {})["concurrency"] = model_config.get(
+            "concurrency",
+            config.get("core", {}).get("concurrency"),
+        )
+
+    if prompt_config:
+        config.setdefault("review", {})["mode"] = prompt_config.get(
+            "mode",
+            config.get("review", {}).get("mode"),
+        )
+
+    if repo_owner or repo_name or pr_number:
+        vcs_section = config.setdefault("vcs", {})
+
+        vcs_section.setdefault("http_client", {})["api_token"] = api_token
+        
+        pipeline = vcs_section.setdefault("pipeline", {})
+        if repo_owner:
+            pipeline["owner"] = repo_owner
+        if repo_name:
+            pipeline["repo"] = repo_name
+        if pr_number:
+            pipeline["pull_number"] = str(pr_number)
+
+    with open(yaml_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(config, f, sort_keys=False, allow_unicode=True)
+
+
+def write_prompt_md(prompt_data: dict, path: str):
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(prompt_data.get("prompt_text", ""))

--- a/consumer/app/worker.py
+++ b/consumer/app/worker.py
@@ -17,9 +17,18 @@ def get_branch(repo, pr, token):
     headers = {"Authorization": f"token {token}"} if token else {}
 
     r = requests.get(url, headers=headers)
+
     if r.status_code == 200:
         return r.json()["head"]["ref"]
-    return None
+    else:
+        logger.error(
+            "github_api_error",
+            status_code=r.status_code,
+            repo=repo,
+            pr=pr,
+            response=r.text[:200]  # Первые 200 символов ответа
+        )
+        return None
 
 
 def callback(ch, method, properties, body):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,8 +98,8 @@ services:
   consumer:
       container_name: consumer
       build:
-        context: ./consumer
-        dockerfile: Dockerfile
+        context: .
+        dockerfile: consumer/Dockerfile
       environment:
         - RABBIT_URL=amqp://${RABBIT_USER}:${RABBIT_PASS}@rabbitmq:5672/
         - GITHUB_TOKEN=${GITHUB_TOKEN}
@@ -107,8 +107,6 @@ services:
       networks:
         - mq_net
         - ai_net
-      volumes:
-      - ./config:/app/config:ro  
       depends_on:
         rabbitmq:
           condition: service_healthy


### PR DESCRIPTION
Теперь конфиг и промпт берутся по новым ручкам для воркера. При старте ревью для репозитория во временную папку копируется файл идентичный config/.ai-review.yaml и в него уже записывается то, что получено от бекенда, а также название репо и гитхаб токен.
Конфиг теперь не монтируется, а копируется при сборке контейнера
Также добавил на бекенд эндпоинт, который возвращает id по паре владелец-имя репозитория